### PR TITLE
fix(customization): allow selective override of component options

### DIFF
--- a/lua/lualine/components/copilot.lua
+++ b/lua/lualine/components/copilot.lua
@@ -50,55 +50,6 @@ function component:init(options)
     component.super.init(self, options)
     self.options = vim.tbl_deep_extend("force", default_options, options or {})
 
-    if options.symbols then
-        -- Icons
-        if options.symbols.status.icons.enabled then
-            options.symbols.status.icons = options.symbols.status.icons or {}
-            options.symbols.status.icons.enabled = options.symbols.status.icons.enabled
-        end
-
-        if options.symbols.status.icons.disabled then
-            options.symbols.status.icons = options.symbols.status.icons or {}
-            options.symbols.status.icons.disabled = options.symbols.status.icons.disabled
-        end
-
-        if options.symbols.status.icons.warning then
-            options.symbols.status.icons = options.symbols.status.icons or {}
-            options.symbols.status.icons.warning = options.symbols.status.icons.warning
-        end
-
-        if options.symbols.status.icons.unknown then
-            options.symbols.status.icons = options.symbols.status.icons or {}
-            options.symbols.status.icons.unknown = options.symbols.status.icons.unknown
-        end
-
-        -- Highlights
-        if options.symbols.status.hl.enabled then
-            options.symbols.status.hl = options.symbols.status.hl or {}
-            options.symbols.status.hl.enabled = options.symbols.status.hl.enabled
-        end
-
-        if options.symbols.status.hl.disabled then
-            options.symbols.status.hl = options.symbols.status.hl or {}
-            options.symbols.status.hl.disabled = options.symbols.status.hl.disabled
-        end
-
-        if options.symbols.status.hl.warning then
-            options.symbols.status.hl = options.symbols.status.hl or {}
-            options.symbols.status.hl.warning = options.symbols.status.hl.warning
-        end
-
-        if options.symbols.status.hl.unknown then
-            options.symbols.status.hl = options.symbols.status.hl or {}
-            options.symbols.status.hl.unknown = options.symbols.status.hl.unknown
-        end
-
-        if options.symbols.spinner_color then
-            options.symbols = options.symbols or {}
-            options.symbols.spinner_color = options.symbols.spinner_color
-        end
-    end
-
     self.highlights = { enabled = '', disabled = '', warning = '' }
 
     self.highlights.enabled = highlight.create_component_highlight_group(


### PR DESCRIPTION
Firstly, I would like to preface this by saying that I may lack some context and the proposed change may be completely misguided, as I lack expertise in both Neovim and Lua, but it seems to solve a problem I was having.

What I was trying to do when configuring this module is simply override the colour of the active/enabled state icon, leaving the rest same as the default options. When I tried this, I couldn't do this without also providing all the other options (icons, etc), as an error was thrown saying that basically the `enabled` property can't be read from the `icons` attribute, which is `nil` here `if options.symbols.status.icons.enabled then`.

The code removed in this commit forced the user to specify all options of the component, even if they only wanted to override a single specific setting. This case seems to be handled by the `vim.tbl_deep_extend` already present in this part of the code.

Now the following customization is possible:

```lua
lualine_x = {
  {
    "copilot",
    symbols = {
      -- no need to specify icons, etc.
      status = {
        hl = {
          enabled = "#74c7ec",
        },
      },
    },
  },
  "progress",
  "location",
},
```