### PR TITLE
Add sleep status

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,22 @@ lualine.setup({
 Customization is available. For example:
 ```lua
 sections = {
-    lualine_x = { 
+    lualine_x = {
         {
             'copilot',
             -- Default values
             symbols = {
                 status = {
                     icons = {
-                        enabled = "",
-                        disabled = "",
-                        warning = "",
-                        unknown = ""
+                        enabled = " ",
+                        sleep = " ",   -- auto-trigger disabled
+                        disabled = " ",
+                        warning = " ",
+                        unknown = " "
                     },
                     hl = {
                         enabled = "#50FA7B",
+                        sleep = "#AEB7D0",
                         disabled = "#6272A4",
                         warning = "#FFB86C",
                         unknown = "#FF5555"

--- a/lua/copilot-lualine/init.lua
+++ b/lua/copilot-lualine/init.lua
@@ -44,4 +44,14 @@ component.is_loading = function()
     return false
 end
 
+---Check auto trigger suggestions
+---@return boolean
+component.is_sleep = function()
+    if c.is_disabled() then
+        return false
+    end
+
+    return vim.b.copilot_suggestion_auto_trigger
+end
+
 return component

--- a/lua/lualine/components/copilot.lua
+++ b/lua/lualine/components/copilot.lua
@@ -9,12 +9,14 @@ local default_options = {
         status = {
             icons = {
                 enabled = " ",
+                sleep = " ",
                 disabled = " ",
                 warning = " ",
                 unknown = " "
             },
             hl = {
                 enabled = "#50FA7B",
+                sleep = "#AEB7D0",
                 disabled = "#6272A4",
                 warning = "#FFB86C",
                 unknown = "#FF5555"
@@ -52,6 +54,9 @@ function component:init(options)
 
     self.highlights = { enabled = '', disabled = '', warning = '' }
 
+    self.highlights.sleep = highlight.create_component_highlight_group(
+        { fg = self.options.symbols.status.hl.sleep },
+        'copilot_sleep', self.options)
     self.highlights.enabled = highlight.create_component_highlight_group(
         { fg = self.options.symbols.status.hl.enabled },
         'copilot_enabled', self.options)
@@ -112,6 +117,12 @@ function component:update_status()
                 self.options.symbols.status.icons.disabled
         end
         return self.options.symbols.status.icons.disabled
+    elseif not copilot.is_sleep() then
+        if self.options.show_colors then
+            return highlight.component_format_highlight(self.highlights.sleep) ..
+                self.options.symbols.status.icons.sleep
+        end
+        return self.options.symbols.status.icons.sleep
     else
         if self.options.show_colors then
             return highlight.component_format_highlight(self.highlights.enabled) ..


### PR DESCRIPTION
`copilot.lua` allows triggering copilot manually, thus copilot can be enabled and sleep.
This is achieved by calling `require("copilot.suggestion").toggle_auto_trigger()`

This PR adds a sleep status to copilot lualine.