### PR TITLE
Allow lazy loading

### DIFF
--- a/lua/copilot-lualine/init.lua
+++ b/lua/copilot-lualine/init.lua
@@ -64,6 +64,9 @@ component.is_sleep = function()
         return false
     end
 
+    if vim.b.copilot_suggestion_auto_trigger == nil then
+        return lazy_require("copilot.config").get("suggestion").auto_trigger
+    end
     return vim.b.copilot_suggestion_auto_trigger
 end
 

--- a/lua/copilot-lualine/init.lua
+++ b/lua/copilot-lualine/init.lua
@@ -1,8 +1,21 @@
 local component = {}
-local status_c, c = pcall(require, "copilot.client")
-if (not status_c) then return end
-local status_a, a = pcall(require, "copilot.api")
-if (not status_a) then return end
+
+-- From TJDevries
+-- https://github.com/tjdevries/lazy-require.nvim
+local function lazy_require(require_path)
+    return setmetatable({}, {
+        __index = function(_, key)
+            return require(require_path)[key]
+        end,
+
+        __newindex = function(_, key, value)
+            require(require_path)[key] = value
+        end,
+    })
+end
+
+local c = lazy_require("copilot.client")
+local a = lazy_require("copilot.api")
 
 ---Check if copilot is enabled
 ---@return boolean

--- a/lua/lualine/components/copilot.lua
+++ b/lua/lualine/components/copilot.lua
@@ -91,7 +91,8 @@ end
 function component:update_status()
     -- All copilot API calls are blocking before copilot is attached,
     -- To avoid blocking the startup time, we check if copilot is attached
-    if not attached then
+    local copilot_loaded = package.loaded["copilot"] ~= nil
+    if not copilot_loaded or not attached then
         if self.options.show_colors then
             return highlight.component_format_highlight(self.highlights.unknown) ..
                 self.options.symbols.status.icons.unknown


### PR DESCRIPTION
With this changes, two things are achieved:

- Lazy loading `copilot.lua` becomes possible. So, this plugin does not require explicitly `copilot`.
- Lualine component handles correctly when `copilot.lua` is not loaded (or does not exist at all).